### PR TITLE
allow conditions on public functions

### DIFF
--- a/libhoare/lib.rs
+++ b/libhoare/lib.rs
@@ -66,7 +66,7 @@ fn precond(cx: &mut ExtCtxt,
 
             let fn_name = ast::Ident::new(token::intern(format!("__inner_fn_{}", fn_name).as_slice()));
             // Construct the inner function.
-            let inner_item = P(Item { attrs: Vec::new(), .. (*item).clone() });
+            let inner_item = P(Item { attrs: Vec::new(), vis: ast::Inherited, .. (*item).clone() });
             stmts.push(fn_decl(sp, fn_name, inner_item));
 
             // Construct the function call.
@@ -110,7 +110,7 @@ fn postcond(cx: &mut ExtCtxt,
             let mut stmts = Vec::new();
             let fn_ident = ast::Ident::new(token::intern(format!("__inner_{}", fn_name).as_slice()));
             // Construct the inner function.
-            let inner_item = P(Item { attrs: Vec::new(), .. (*item).clone() });
+            let inner_item = P(Item { attrs: Vec::new(), vis: ast::Inherited, .. (*item).clone() });
             stmts.push(fn_decl(sp, fn_ident, inner_item));
 
             // Construct the function call.
@@ -156,7 +156,7 @@ fn invariant(cx: &mut ExtCtxt,
 
             let fn_ident = ast::Ident::new(token::intern(format!("__inner_{}", fn_name).as_slice()));
             // Construct the inner function.
-            let inner_item = P(Item { attrs: Vec::new(), .. (*item).clone() });
+            let inner_item = P(Item { attrs: Vec::new(), vis: ast::Inherited, .. (*item).clone() });
             stmts.push(fn_decl(sp, fn_ident, inner_item));
 
             // Construct the function call.

--- a/test/mod.rs
+++ b/test/mod.rs
@@ -14,6 +14,9 @@
 extern crate hoare;
 
 #[cfg(test)]
+pub use test::pub_test_trivial_4;
+
+#[cfg(test)]
 mod test {
     #[test]
     #[precond="true"]
@@ -41,6 +44,33 @@ mod test {
     #[should_fail]
     #[invariant="false"]
     fn test_fail_trivial_3() {}
+
+    #[test]
+    #[precond="true"]
+    pub fn pub_test_trivial_1() {}
+    #[test]
+    #[postcond="true"]
+    pub fn pub_test_trivial_2() {}
+    #[test]
+    #[invariant="true"]
+    pub fn pub_test_trivial_3() {}
+    #[test]
+    #[precond="true"]
+    #[postcond="true"]
+    #[invariant="true"]
+    pub fn pub_test_trivial_4() {}
+    #[test]
+    #[should_fail]
+    #[precond="false"]
+    pub fn pub_test_fail_trivial_1() {}
+    #[test]
+    #[should_fail]
+    #[postcond="false"]
+    pub fn pub_test_fail_trivial_2() {}
+    #[test]
+    #[should_fail]
+    #[invariant="false"]
+    pub fn pub_test_fail_trivial_3() {}
 
     #[test]
     #[precond="4u32 < 5"]


### PR DESCRIPTION
standard lints disallow public inner functions, this makes the inner functions have inherited visibility.
